### PR TITLE
Grammar in exception message

### DIFF
--- a/Dotenv.php
+++ b/Dotenv.php
@@ -212,7 +212,7 @@ final class Dotenv
         }
 
         if (' ' === $this->data[$this->cursor] || "\t" === $this->data[$this->cursor]) {
-            throw $this->createFormatException('Whitespace are not supported after the variable name');
+            throw $this->createFormatException('Whitespace characters are not supported after the variable name');
         }
 
         if ('=' !== $this->data[$this->cursor]) {


### PR DESCRIPTION
According to https://en.wiktionary.org/wiki/whitespace and https://english.stackexchange.com/questions/25368/what-is-the-plural-form-of-whitespace valid sentences would be:
- Whitespace is ...
- Whitespaces are ...
- Whitespace characters are ...
But this is not correct:
- Whitespace are ...