### PR TITLE
Should the .env.local override the .env value?

### DIFF
--- a/Dotenv.php
+++ b/Dotenv.php
@@ -100,7 +100,7 @@ final class Dotenv
         }
 
         if (file_exists($p = "$path.$env.local")) {
-            $this->load($p);
+            $this->overload($p);
         }
     }
 


### PR DESCRIPTION
Isn't it relevant to use the overload method when considering a .env.***.local file?
At the moment, it's difficult to override the .env value if you have to change a parameter for any reason.

It's a question, as I haven't get deeply in the component.